### PR TITLE
fix(sms): check if the response contains `SUCCESS`

### DIFF
--- a/src/auth/sms.ts
+++ b/src/auth/sms.ts
@@ -43,7 +43,7 @@ export class SmsVerification {
     const body = JSON.stringify({ ...this.body, source: 'android-button' });
     const response = await RestManager.request('POST', 'auth/sendVerificationSms', { body });
     const text = (await response.text()) as SendVerificationSmsResponse;
-    if (text !== 'SUCCESS') throw new Error(text);
+    if (!text.includes('SUCCESS')) throw new Error(text);
   }
 
   /**


### PR DESCRIPTION
The api must have changed.
When succesfull, `sendVerificationSms` usually returns something like this:
```json
{"realmChallenge":null,"errorMessage":null,"status":"SUCCESS"}
```
and not just `SUCCESS`.
This commit fixes the issue in the probably worst possible way.