### PR TITLE
fix(sms): bump appVersionName to avoid TOO_OLD_APP_VERSION error

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 export const applicationId = 'com.moshbit.studo';
 export const appVersionCode = 4060;
-export const appVersionName = '4.06.0';
+export const appVersionName = '4.64.3';
 export const appVersionDate = '2021-09-19T02:00:01.000Z';
 
 export const deviceName = 'studo.js client';


### PR DESCRIPTION
Studo now apparently checks if the app version in the user agent header is too old and returns `TOO_OLD_APP_VERSION`.
Just bumping the version name seems to fix this for now.
No idea if it always has to be the newest one.